### PR TITLE
update FLIP_LEFT_RIGHT definition to fix deprecation warning

### DIFF
--- a/linedraw.py
+++ b/linedraw.py
@@ -94,7 +94,7 @@ def getcontours(IM,sc=2):
     print("generating contours...")
     IM = find_edges(IM)
     IM1 = IM.copy()
-    IM2 = IM.rotate(-90,expand=True).transpose(Image.FLIP_LEFT_RIGHT)
+    IM2 = IM.rotate(-90,expand=True).transpose(Image.Transpose.FLIP_LEFT_RIGHT)
     dots1 = getdots(IM1)
     contours1 = connectdots(dots1)
     dots2 = getdots(IM2)


### PR DESCRIPTION
I noticed this warning which was occurring when using the script.

```
/Users/richardmonette/src/linedraw/linedraw.py:97: DeprecationWarning: FLIP_LEFT_RIGHT is deprecated and will be removed in Pillow 10 (2023-07-01). Use Transpose.FLIP_LEFT_RIGHT instead.
  IM2 = IM.rotate(-90,expand=True).transpose(Image.FLIP_LEFT_RIGHT)
```

Went ahead and made a quick PR to fix 🙂 

